### PR TITLE
Redirect authenticated users to home

### DIFF
--- a/FE/src/router/index.js
+++ b/FE/src/router/index.js
@@ -25,9 +25,15 @@ router.beforeEach((to, from, next) => {
 
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {
     next("/login")
-  } else {
-    next()
+    return
   }
+
+  if (to.path === "/login" && authStore.isAuthenticated) {
+    next("/")
+    return
+  }
+
+  next()
 })
 
 export default router


### PR DESCRIPTION
## Summary
- prevent authenticated users from staying on the login page by redirecting them to home
- keep existing auth guard behavior for protected routes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c5af640483328bf270cb60c6adf6)